### PR TITLE
Option to skip domain verification

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -31,6 +31,10 @@ pub fn verify_asset_link(asset: &Asset) -> Result<()> {
 fn verify_domain_link(asset: &Asset, domain: &str) -> Result<()> {
     verify_domain_name(domain).context("invalid domain name")?;
 
+    if std::env::var_os("SKIP_VERIFY_DOMAIN_LINK").is_some() {
+        return Ok(());
+    }
+
     // TODO tor proxy for accessing onion
 
     let asset_id = asset.id().to_hex();


### PR DESCRIPTION
For integration testing using regtest the domain verification can be skipped