### PR TITLE
contrib: Fix hook script to allow archiving a longer list of files

### DIFF
--- a/contrib/hook.sh
+++ b/contrib/hook.sh
@@ -53,7 +53,7 @@ main() {
   cp $full_index_path $minimal_index_path $WWW_PATH/
 
   # Update tar.xz archive
-  tar cJf $archive_path _map ??/*.json
+  (echo _map && find . -path "./??/*.json" -print) | tar cJf "$archive_path" --files-from=-
 }
 
 index_add_asset() {


### PR DESCRIPTION
We ran into an issue with the Liquid Testnet Registry, where new assets cannot be added/deleted since the `tar` command that produces `index.tar.xz` ran into the shell's argument list limit (25k+ total assets).
```
...
/app/hook.sh: line 56: /bin/tar: Argument list too long
```

The PR addresses that issue.

Tested by manually making the changes on the running VM's `registry` container.